### PR TITLE
Add support for graphs with gaps

### DIFF
--- a/spark/src/main/java/com/robinhood/spark/SparkAdapter.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkAdapter.java
@@ -53,6 +53,14 @@ public abstract class SparkAdapter {
     public abstract float getY(int index);
 
     /**
+     * @return Whether a the point at the given index should be drawn connected to the graph.
+     * By default, every point in the adapter will connect to the graph.
+     */
+    protected boolean shouldConnect(int index) {
+        return true;
+    }
+
+    /**
      * Gets the float representation of the boundaries of the entire dataset. By default, this will
      * be the min and max of the actual data points in the adapter. This can be overridden for
      * custom behavior. When overriding, make sure to set RectF's values such that:


### PR DESCRIPTION
This allows for graphs like the following:

![screen shot 2019-03-01 at 3 22 38 pm](https://user-images.githubusercontent.com/1651191/53664207-e423de80-3c35-11e9-962e-6382a660c1c2.png)

Tested with graphs with and without gaps, with all different fill types.